### PR TITLE
Set summaryLastWeek and summaryThisWeek correct dateranges.

### DIFF
--- a/src/Traits/ReportUtilityTrait.php
+++ b/src/Traits/ReportUtilityTrait.php
@@ -11,7 +11,6 @@ trait ReportUtilityTrait {
             ->startOfWeek()
             ->toDateString();
         $data[ 'until' ] = Carbon::now()
-            ->subWeek()
             ->endOfWeek()
             ->toDateString();
 
@@ -21,6 +20,7 @@ trait ReportUtilityTrait {
     public function summaryLastWeek(array $data = array())
     {
         $data[ 'since' ] = Carbon::now()
+            ->subWeek()
             ->startOfWeek()
             ->toDateString();
         $data[ 'until' ] = Carbon::now()


### PR DESCRIPTION
Set summaryLastWeek and summaryThisWeek correct date ranges. This was previously showing an error as the since date occurred after the until date for both methods.