### PR TITLE
Support for laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,11 @@
 
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": ">=5.0",
         "nesbot/carbon": ">=1.19",
         "ixudra/curl": "~6.0"
+    },
+    "suggest": {
+        "illuminate/support": "Support for laravel using the TogglServiceProvider"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.6.0",
         "illuminate/support": ">=5.0",
-        "nesbot/carbon": "~1.19",
+        "nesbot/carbon": ">=1.19",
         "ixudra/curl": "~6.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require": {
         "php": ">=5.6.0",
-        "illuminate/support": "~5.0",
+        "illuminate/support": ">=5.0",
         "nesbot/carbon": "~1.19",
         "ixudra/curl": "~6.0"
     },


### PR DESCRIPTION
Adds support for laravel 6.
Changes:
 - illuminate/support is no longer a requirement but rather a suggestion since it should only be used if using laravel.
- nesbot/carbon's version can now be 1.19 or higher, since in laravel 6.0 carbon 2 is used.

It is completely compatible backwards.