### PR TITLE
Added the ability to pass parameters when getting workspace projects

### DIFF
--- a/src/Traits/WorkspaceTrait.php
+++ b/src/Traits/WorkspaceTrait.php
@@ -37,12 +37,13 @@ trait WorkspaceTrait {
 
     /**
      * Get workspace projects
-     *
+     * 
+     * @param   array       $data       Data payload that is to be sent with the request
      * @return stdClass
      */
-    public function workspaceProjects()
+    public function workspaceProjects( array $data = array() )
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/projects');
+        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/projects', $data);
     }
 
     /**


### PR DESCRIPTION
This allows you to pass the parameters provided here to retrieve active/inactive/both types of projects: https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md#get-workspace-projects

To use simply call workspaceProjects and pass in the parmeters like this:
```PHP
$all_projects = Toggl::workspaceProjects(['active' => 'both']);
```