### PR TITLE
Update to v9

### DIFF
--- a/src/TogglService.php
+++ b/src/TogglService.php
@@ -33,12 +33,16 @@ class TogglService {
     /** @var string $baseUrl */
     protected $baseUrl = null;
 
+    /** @var string $apiVersion */
+    protected $apiVersionUrl = null;
+
 
     public function __construct($workspaceId = null, $apiToken = null)
     {
         $this->workspaceId = $workspaceId;
         $this->apiToken = $apiToken;
         $this->baseUrl = 'https://api.track.toggl.com';
+        $this->apiVersionUrl = '/api/v9';
     }
 
 

--- a/src/Traits/ClientTrait.php
+++ b/src/Traits/ClientTrait.php
@@ -12,7 +12,7 @@ trait ClientTrait {
      */
     public function clients()
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/clients' );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/clients' );
     }
 
     /**
@@ -28,7 +28,7 @@ trait ClientTrait {
             'client'        => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/clients', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/clients', $requestData );
     }
 
     /**
@@ -39,7 +39,7 @@ trait ClientTrait {
      */
     public function client($id)
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/clients/'. $id );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/clients/'. $id );
     }
 
     /**
@@ -55,7 +55,7 @@ trait ClientTrait {
             'client'        => $data,
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/clients/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/clients/'. $id, $requestData );
     }
 
     /**
@@ -66,7 +66,7 @@ trait ClientTrait {
      */
     public function deleteClient($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/clients/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/clients/'. $id );
     }
 
     /**
@@ -78,7 +78,7 @@ trait ClientTrait {
      */
     public function clientProjects($id, array $data = array())
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/clients/'. $id .'/projects', $data );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/clients/'. $id .'/projects', $data );
     }
 
 }

--- a/src/Traits/GroupTrait.php
+++ b/src/Traits/GroupTrait.php
@@ -18,7 +18,7 @@ trait GroupTrait {
             'group'        => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/groups', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/groups', $requestData );
     }
 
     /**
@@ -34,7 +34,7 @@ trait GroupTrait {
             'group'         => $data,
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/groups/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/groups/'. $id, $requestData );
     }
 
     /**
@@ -45,7 +45,7 @@ trait GroupTrait {
      */
     public function deleteGroup($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/groups/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/groups/'. $id );
     }
 
 }

--- a/src/Traits/ProjectTrait.php
+++ b/src/Traits/ProjectTrait.php
@@ -12,7 +12,7 @@ trait ProjectTrait {
      */
     public function projects()
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/projects' );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/projects' );
     }
 
     /**
@@ -28,7 +28,7 @@ trait ProjectTrait {
             'project'        => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/projects', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/projects', $requestData );
     }
 
     /**
@@ -39,7 +39,7 @@ trait ProjectTrait {
      */
     public function project($id)
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/projects/'. $id );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/projects/'. $id );
     }
 
     /**
@@ -55,7 +55,7 @@ trait ProjectTrait {
             'project'        => $data,
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/projects/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/projects/'. $id, $requestData );
     }
 
     /**
@@ -66,7 +66,7 @@ trait ProjectTrait {
      */
     public function deleteProject($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/projects/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/projects/'. $id );
     }
 
     /**
@@ -78,7 +78,7 @@ trait ProjectTrait {
      */
     public function projectUsers($id, array $data = array())
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/projects/'. $id .'/project_users', $data );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/projects/'. $id .'/project_users', $data );
     }
 
     /**
@@ -90,7 +90,7 @@ trait ProjectTrait {
      */
     public function projectTasks($id, array $data = array())
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/projects/'. $id .'/tasks', $data );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/projects/'. $id .'/tasks', $data );
     }
 
 }

--- a/src/Traits/ReportTrait.php
+++ b/src/Traits/ReportTrait.php
@@ -12,7 +12,7 @@ trait ReportTrait {
      */
     public function dashboard()
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/dashboard/'. $this->workspaceId );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/dashboard/'. $this->workspaceId );
     }
 
     /**

--- a/src/Traits/TagTrait.php
+++ b/src/Traits/TagTrait.php
@@ -18,7 +18,7 @@ trait TagTrait {
             'tag'       => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/tags', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/tags', $requestData );
     }
 
     /**
@@ -34,7 +34,7 @@ trait TagTrait {
             'tag'       => $data
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/tags/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/tags/'. $id, $requestData );
     }
 
     /**
@@ -45,7 +45,7 @@ trait TagTrait {
      */
     public function deleteTag($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/tags/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/tags/'. $id );
     }
 
 }

--- a/src/Traits/TaskTrait.php
+++ b/src/Traits/TaskTrait.php
@@ -18,7 +18,7 @@ trait TaskTrait {
             'task'          => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/tasks', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/tasks', $requestData );
     }
 
     /**
@@ -29,7 +29,7 @@ trait TaskTrait {
      */
     public function task($id)
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/tasks/'. $id );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/tasks/'. $id );
     }
 
     /**
@@ -45,7 +45,7 @@ trait TaskTrait {
             'task'          => $data,
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/tasks/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/tasks/'. $id, $requestData );
     }
 
     /**
@@ -56,7 +56,7 @@ trait TaskTrait {
      */
     public function deleteTask($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/tasks/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/tasks/'. $id );
     }
 
 }

--- a/src/Traits/TimeEntryTrait.php
+++ b/src/Traits/TimeEntryTrait.php
@@ -20,7 +20,7 @@ trait TimeEntryTrait {
             'end_date'      => $endDate->toIso8601ZuluString(),
         );
 
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/time_entries', $requestData );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries', $requestData );
     }
 
     /**
@@ -36,7 +36,7 @@ trait TimeEntryTrait {
             'time_entry'    => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/time_entries', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries', $requestData );
     }
 
     /**
@@ -52,7 +52,7 @@ trait TimeEntryTrait {
             'time_entry'    => $data,
         );
 
-        return $this->sendPostMessage( $this->baseUrl .'/api/v8/time_entries/start', $requestData );
+        return $this->sendPostMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/start', $requestData );
     }
 
     /**
@@ -63,7 +63,7 @@ trait TimeEntryTrait {
      */
     public function stopTimeEntry($id)
     {
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/time_entries/'. $id .'/stop' );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/'. $id .'/stop' );
     }
 
     /**
@@ -74,9 +74,9 @@ trait TimeEntryTrait {
      */
     public function timeEntry($id)
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/time_entries/'. $id );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/'. $id );
     }
-    
+
     /**
      * Summary report returns the aggregated time entries data
      *
@@ -84,7 +84,7 @@ trait TimeEntryTrait {
      */
     public function entry()
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/time_entries' );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries' );
     }
 
     /**
@@ -94,7 +94,7 @@ trait TimeEntryTrait {
      */
     public function current()
     {
-        return $this->sendGetMessage( $this->baseUrl .'/api/v8/time_entries/current' );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/current' );
     }
 
     /**
@@ -110,7 +110,7 @@ trait TimeEntryTrait {
             'time_entry'    => $data
         );
 
-        return $this->sendPutMessage( $this->baseUrl .'/api/v8/time_entries/'. $id, $requestData );
+        return $this->sendPutMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/'. $id, $requestData );
     }
 
     /**
@@ -121,7 +121,7 @@ trait TimeEntryTrait {
      */
     public function deleteTimeEntry($id)
     {
-        return $this->sendDeleteMessage( $this->baseUrl .'/api/v8/time_entries/'. $id );
+        return $this->sendDeleteMessage( $this->baseUrl . $this->apiVersionUrl . '/time_entries/'. $id );
     }
 
 }

--- a/src/Traits/WorkspaceTrait.php
+++ b/src/Traits/WorkspaceTrait.php
@@ -12,9 +12,9 @@ trait WorkspaceTrait {
      */
     public function workspaces()
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces');
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces');
     }
-    
+
     /**
      * Get workspace clients
      *
@@ -22,9 +22,9 @@ trait WorkspaceTrait {
      */
     public function workspaceClients()
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/clients');
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/clients');
     }
-    
+
     /**
      * Get workspace groups
      *
@@ -32,18 +32,18 @@ trait WorkspaceTrait {
      */
     public function workspaceGroups()
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/groups');
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/groups');
     }
 
     /**
      * Get workspace projects
-     * 
+     *
      * @param   array       $data           Data payload that is to be sent with the request
      * @return stdClass
      */
     public function workspaceProjects(array $data = array())
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/projects', $data);
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/projects', $data);
     }
 
     /**
@@ -54,13 +54,13 @@ trait WorkspaceTrait {
      */
     public function workspaceTasks($active = true)
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/tasks',
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/tasks',
             array(
                 'active'    => $active,
             )
         );
     }
-    
+
     /**
      * Get workspace tags
      *
@@ -68,7 +68,7 @@ trait WorkspaceTrait {
      */
     public function workspaceTags()
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/tags');
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/tags');
     }
 
 }

--- a/src/Traits/WorkspaceUsersTrait.php
+++ b/src/Traits/WorkspaceUsersTrait.php
@@ -20,7 +20,7 @@ trait WorkspaceUsersTrait
             'emails'          => $data,
         );
 
-        return $this->sendPostMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/invite', $requestData);
+        return $this->sendPostMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/invite', $requestData);
     }
 
     /**
@@ -36,7 +36,7 @@ trait WorkspaceUsersTrait
             'workspace_user'          => $data,
         );
 
-        return $this->sendPostMessage($this->baseUrl .'/api/v8/workspace_users/'. $id, $requestData);
+        return $this->sendPostMessage($this->baseUrl . $this->apiVersionUrl . '/workspace_users/'. $id, $requestData);
     }
 
     /**
@@ -51,7 +51,7 @@ trait WorkspaceUsersTrait
             'task'          => $data,
         );
 
-        return $this->sendDeleteMessage($this->baseUrl .'/api/v8/workspace_users/'. $id);
+        return $this->sendDeleteMessage($this->baseUrl . $this->apiVersionUrl . '/workspace_users/'. $id);
     }
 
     /**
@@ -61,7 +61,7 @@ trait WorkspaceUsersTrait
      */
     public function users()
     {
-        return $this->sendGetMessage($this->baseUrl .'/api/v8/workspaces/' . $this->workspaceId . '/workspace_users');
+        return $this->sendGetMessage($this->baseUrl . $this->apiVersionUrl . '/workspaces/' . $this->workspaceId . '/workspace_users');
     }
 
 }


### PR DESCRIPTION
V8 toggle api is showing that message:

"The V8 endpoint is scheduled to be shutdown on 23/05/2024, this is a brownout. Please find the migration guide at https://engineering.toggl.com/changes/2022/10/01/api-v8-deprecation/index.html"

So in this pr I update the api url to v9.