### PR TITLE
Update dashboard overview url

### DIFF
--- a/src/Traits/ReportTrait.php
+++ b/src/Traits/ReportTrait.php
@@ -12,7 +12,7 @@ trait ReportTrait {
      */
     public function dashboard()
     {
-        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/dashboard/'. $this->workspaceId );
+        return $this->sendGetMessage( $this->baseUrl . $this->apiVersionUrl . '/workspaces/'. $this->workspaceId . '/dashboard/all_activity' );
     }
 
     /**


### PR DESCRIPTION
There is a url change in ReportTrait according to: https://engineering.toggl.com/docs/additional/v8_migration_guide/index.html