### PR TITLE
Fix deprecation warning for nullable parameter.

### DIFF
--- a/src/Traits/TimeEntryTrait.php
+++ b/src/Traits/TimeEntryTrait.php
@@ -9,11 +9,11 @@ trait TimeEntryTrait {
     /**
      * Get time entries started in a specific time range
      *
-     * @param   Carbon      $startDate  Start of date range
-     * @param   Carbon      $endDate    End of date range
+     * @param   Carbon|null      $startDate  Start of date range
+     * @param   Carbon|null      $endDate    End of date range
      * @return  stdClass
      */
-    public function timeEntries(Carbon $startDate = null, Carbon $endDate = null)
+    public function timeEntries(?Carbon $startDate, ?Carbon $endDate)
     {
         $requestData = array();
         if( !empty($startDate) || !empty($endDate) ) {


### PR DESCRIPTION
Using ixudra/toggl with PHP8.4 results in a deprecation warning:

```
Deprecated: Ixudra\Toggl\Traits\TimeEntryTrait::timeEntries(): Implicitly marking parameter $endDate as nullable is deprecated, the explicit nullable type must be used instead in .../vendor/ixudra/toggl/src/Traits/TimeEntryTrait.php on line 16
```
